### PR TITLE
Update dependencies and replace deprecated seaborn usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@ This repository contains data and code related to an introduction to pandas, a p
 
 # Installation
 
-To use the code and datasets in this repository, you need to have Python and pandas installed. You can install pandas using pip:
+To use the code and datasets in this repository, you need Python plus the main
+libraries used throughout the notebooks:
+
+- pandas
+- NumPy
+- matplotlib
+- seaborn
+- scikit-learn
+
+You can install them with pip:
 
 ```bash
-pip install pandas
+pip install pandas numpy matplotlib seaborn scikit-learn
 ```
 
 # Usage

--- a/introonpandas_viz.ipynb
+++ b/introonpandas_viz.ipynb
@@ -182,7 +182,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>78 rows × 6 columns</p>\n",
+       "<p>78 rows \u00d7 6 columns</p>\n",
        "</div>\n",
        "    <div class=\"colab-df-buttons\">\n",
        "\n",
@@ -1521,7 +1521,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>78 rows × 6 columns</p>\n",
+       "<p>78 rows \u00d7 6 columns</p>\n",
        "</div>\n",
        "    <div class=\"colab-df-buttons\">\n",
        "\n",
@@ -4318,7 +4318,7 @@
    "source": [
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
-    "sn.distplot(df1['Accept'])\n",
+    "sn.histplot(df1['Accept'], kde=True)\n",
     "plt.show()"
    ]
   },


### PR DESCRIPTION
## Summary
- document all Python libraries required to run the notebooks
- replace deprecated seaborn.distplot with seaborn.histplot to avoid runtime errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af5cd1f588325ae8af9daf265e808)